### PR TITLE
webview: silence warnings using -Wno-deprecated-declarations

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -11,7 +11,7 @@
 package webview
 
 /*
-#cgo linux openbsd freebsd CFLAGS: -DWEBVIEW_GTK=1
+#cgo linux openbsd freebsd CFLAGS: -DWEBVIEW_GTK=1 -Wno-deprecated-declarations
 #cgo linux openbsd freebsd pkg-config: gtk+-3.0 webkit2gtk-4.0
 
 #cgo windows CFLAGS: -DWEBVIEW_WINAPI=1


### PR DESCRIPTION
Temporary fix to wailsapp/wails#247.

After this commit, there are no deprecated declaration warnings printed.

Before this commit:

	# github.com/wailsapp/webview
	In file included from webview.go:27,
						  from _cgo_export.c:4:
	/home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h: In function ‘external_message_received_cb’:
	/home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h:278:5: warning: ‘webkit_javascript_result_get_global_context’ is deprecated [-Wdeprecated-declarations]
	  278 |     JSGlobalContextRef context = webkit_javascript_result_get_global_context(r);
			|     ^~~~~~~~~~~~~~~~~~
	In file included from /usr/include/webkitgtk-4.0/webkit2/webkit2.h:56,
						  from /home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h:45,
						  from webview.go:27,
						  from _cgo_export.c:4:
	/usr/include/webkitgtk-4.0/webkit2/WebKitJavascriptResult.h:49:1: note: declared here
		49 | webkit_javascript_result_get_global_context (WebKitJavascriptResult *js_result);
			| ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	In file included from webview.go:27,
						  from _cgo_export.c:4:
	/home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h:279:5: warning: ‘webkit_javascript_result_get_value’ is deprecated: Use 'webkit_javascript_result_get_js_value' instead [-Wdeprecated-declarations]
	  279 |     JSValueRef value = webkit_javascript_result_get_value(r);
			|     ^~~~~~~~~~
	In file included from /usr/include/webkitgtk-4.0/webkit2/webkit2.h:56,
						  from /home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h:45,
						  from webview.go:27,
						  from _cgo_export.c:4:
	/usr/include/webkitgtk-4.0/webkit2/WebKitJavascriptResult.h:52:1: note: declared here
		52 | webkit_javascript_result_get_value          (WebKitJavascriptResult *js_result);
			| ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	# github.com/wailsapp/webview
	In file included from /home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.go:27:
	/home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h: In function ‘external_message_received_cb’:
	/home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h:278:5: warning: ‘webkit_javascript_result_get_global_context’ is deprecated [-Wdeprecated-declarations]
	  278 |     JSGlobalContextRef context = webkit_javascript_result_get_global_context(r);
			|     ^~~~~~~~~~~~~~~~~~
	In file included from /usr/include/webkitgtk-4.0/webkit2/webkit2.h:56,
						  from /home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h:45,
						  from /home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.go:27:
	/usr/include/webkitgtk-4.0/webkit2/WebKitJavascriptResult.h:49:1: note: declared here
		49 | webkit_javascript_result_get_global_context (WebKitJavascriptResult *js_result);
			| ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	In file included from /home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.go:27:
	/home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h:279:5: warning: ‘webkit_javascript_result_get_value’ is deprecated: Use 'webkit_javascript_result_get_js_value' instead [-Wdeprecated-declarations]
	  279 |     JSValueRef value = webkit_javascript_result_get_value(r);
			|     ^~~~~~~~~~
	In file included from /usr/include/webkitgtk-4.0/webkit2/webkit2.h:56,
						  from /home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.h:45,
						  from /home/u/goget/pkg/mod/github.com/wailsapp/webview@v0.2.7/webview.go:27:
	/usr/include/webkitgtk-4.0/webkit2/WebKitJavascriptResult.h:52:1: note: declared here
		52 | webkit_javascript_result_get_value          (WebKitJavascriptResult *js_result);
			| ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~